### PR TITLE
Fix IP Forwarding

### DIFF
--- a/src/protocolsupport/protocol/pipeline/initial/InitialPacketDecoder.java
+++ b/src/protocolsupport/protocol/pipeline/initial/InitialPacketDecoder.java
@@ -215,7 +215,7 @@ public class InitialPacketDecoder extends SimpleChannelInboundHandler<ByteBuf> {
 				pipeline.addAfter(PipelineUtils.FRAME_DECODER, "decompress", new PacketDecompressor());
 				pipeline.addAfter(PipelineUtils.FRAME_PREPENDER, "compress", new PacketCompressor(256));
 			}
-			if ((encapsulatedinfo.getAddress() != null) && connection.getRawAddress().getAddress().isLoopbackAddress()) {
+			if ((encapsulatedinfo.getAddress() != null)) {
 				connection.changeAddress(encapsulatedinfo.getAddress());
 			}
 		}


### PR DESCRIPTION
This PR fixes IP Forwarding for PE players.

Older PC versions continue to work as intended.